### PR TITLE
Fix/lab 02 readme.md

### DIFF
--- a/labs/02-pre-commit/README.md
+++ b/labs/02-pre-commit/README.md
@@ -194,7 +194,7 @@ cd security-by-design/labs/02-pre-commit
 ```
 
 ```bash
-docker build -t labs/pre-commit-hooks .
+docker build -t labs/02-pre-commit .
 ```
 
 ### 3. Starten des Containers

--- a/labs/02-pre-commit/README.md
+++ b/labs/02-pre-commit/README.md
@@ -1,6 +1,6 @@
-# 00 Pre-Commit
+# 02 Pre-Commit
 
-- [00 Pre-Commit](#00-pre-commit)
+- [02 Pre-Commit](#02-pre-commit)
   - [Durchführung](#durchführung)
     - [1. Betrachte das Setup im Container](#1-betrachte-das-setup-im-container)
     - [2. Untersuche das Git-Repository](#2-untersuche-das-git-repository)


### PR DESCRIPTION
Hello @V0idC0de,


while i was reworking lab 02 (pre-commit), i got this error:

Unable to find image 'labs/02-pre-commit:latest' locally
docker: Error response from daemon: pull access denied for labs/02-pre-commit, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
Run 'docker run --help' for more information

Then i looked into the provided guide for the lab and noticed that with the docker build command the container image identifier tag is set to "labs/pre-commit-hooks":

=> => naming to docker.io/labs/pre-commit-hooks                                                                   0.0s

Because in the next command (docker run) the container image identifier tag is "labs/02-pre-commit" the built image can not be found and you get the error.

With this pull request i fixed this issue and i fixed the numbering of the lab "pre-commit" in its own guide, so it matches the whole order (00 -> 02).


Best regards,
Marv2806